### PR TITLE
Add non-regression testing github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on: [ push, pull_request ]
+
+jobs:
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        luaVersion: ['luajit', '5.1', '5.2', '5.3', '5.4.4']
+    runs-on: ubuntu-22.04
+    name: test lua ${{ matrix.luaVersion }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup ‘lua’
+        uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+          buildCache: true
+      - name: Test
+        run: |
+          lua qrtest.lua

--- a/qrtest.lua
+++ b/qrtest.lua
@@ -120,3 +120,4 @@ if failed then
 else
 	print("Everything looks fine")
 end
+os.exit(failed and 1 or 0)


### PR DESCRIPTION
This PR is a proposal to add a GitHub action to the repository for ensuring the tests (`qrtest.lua`) are run on every code change (push/pull), and on a matrix of Lua versions (from luajit to 5.4.4) so that compatibility is also checked.