### PR TITLE
ci: Update LuaCheck workflow to use latest version

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1


### PR DESCRIPTION
Sorry I didn't catch this on the PR where it was submitted (which I reviewed at the time but missed the version being out of date). The first v1 series release of LuaCheck was Aug 2022. The `v1` tag should keep tracking the latest releases until we bump the major version for some breaking change. This should be safe for the foreseeable future.